### PR TITLE
[Fix] 상대 누적량 제대로 표시되지 않는 문제 수정

### DIFF
--- a/features/orderbook/domain/src/main/java/com/junyoung/ha/features/orderbook/domain/model/OrderBook.kt
+++ b/features/orderbook/domain/src/main/java/com/junyoung/ha/features/orderbook/domain/model/OrderBook.kt
@@ -3,6 +3,7 @@ package com.junyoung.ha.features.orderbook.domain.model
 import com.junyoung.ha.features.common.domain.Price
 import java.lang.Integer.max
 import java.math.BigDecimal
+import java.math.RoundingMode
 
 data class OrderBook(
     val buyOrderList: OrderList = OrderList.EMPTY,
@@ -21,10 +22,10 @@ data class OrderBook(
     fun getRelativeQuantity(orderType: OrderType, price: Price): Float {
         return when (orderType) {
             OrderType.BUY -> {
-                buyOrderList.getCumulativeQuantity(price) / getMaxCumulativeQuantity()
+                buyOrderList.getCumulativeQuantity(price).setScale(4, RoundingMode.HALF_EVEN) / getMaxCumulativeQuantity()
             }
             OrderType.SELL -> {
-                sellOrderList.getCumulativeQuantity(price) / getMaxCumulativeQuantity()
+                sellOrderList.getCumulativeQuantity(price).setScale(4, RoundingMode.HALF_EVEN) / getMaxCumulativeQuantity()
             }
         }.toFloat()
     }


### PR DESCRIPTION
[이슈원인] Bitmex의 사이즈가 정수형으로 오다보니 정수형으로 연산됨

[이슈해결] 실수형으로 연산되도록 수정